### PR TITLE
Refactor TestWebhook to use resty for HTTP requests and update depend…

### DIFF
--- a/cmd/skill/main_test.go
+++ b/cmd/skill/main_test.go
@@ -5,11 +5,20 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/go-resty/resty/v2"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestWebhook(t *testing.T) {
-	// описываем ожидаемое тело ответа при успешном запросе
+	// тип http.HandlerFunc реализует интерфейс http.Handler
+	// это поможет передать хендлер тестовому серверу
+	handler := http.HandlerFunc(webhook)
+	// запускаем тестовый сервер, будет выбран первый свободный порт
+	srv := httptest.NewServer(handler)
+	// останавливаем сервер после завершения теста
+	defer srv.Close()
+
+	// ожидаемое содержимое тела ответа при успешном запросе
 	successBody := `{
         "response": {
             "text": "Извините, я пока ничего не умею"
@@ -31,17 +40,19 @@ func TestWebhook(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.method, func(t *testing.T) {
-			r := httptest.NewRequest(tc.method, "/", nil)
-			w := httptest.NewRecorder()
+			// делаем запрос с помощью библиотеки resty к адресу запущенного сервера,
+			// который хранится в поле URL соответствующей структуры
+			req := resty.New().R()
+			req.Method = tc.method
+			req.URL = srv.URL
 
-			// вызовем хендлер как обычную функцию, без запуска самого сервера
-			webhook(w, r)
+			resp, err := req.Send()
+			assert.NoError(t, err, "error making HTTP request")
 
-			assert.Equal(t, tc.expectedCode, w.Code, "Код ответа не совпадает с ожидаемым")
-			// проверим корректность полученного тела ответа, если мы его ожидаем
+			assert.Equal(t, tc.expectedCode, resp.StatusCode(), "Response code didn't match expected")
+			// проверяем корректность полученного тела ответа, если мы его ожидаем
 			if tc.expectedBody != "" {
-				// assert.JSONEq помогает сравнить две JSON-строки
-				assert.JSONEq(t, tc.expectedBody, w.Body.String(), "Тело ответа не совпадает с ожидаемым")
+				assert.JSONEq(t, tc.expectedBody, string(resp.Body()))
 			}
 		})
 	}

--- a/go.mod
+++ b/go.mod
@@ -2,10 +2,14 @@ module github.com/kurepinvladimir/alice-skill
 
 go 1.24.3
 
-require github.com/stretchr/testify v1.10.0
+require (
+	github.com/go-resty/resty/v2 v2.16.5
+	github.com/stretchr/testify v1.10.0
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/net v0.33.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,15 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/go-resty/resty/v2 v2.16.5 h1:hBKqmWrr7uRc3euHVqmh1HTHcKn99Smr7o5spptdhTM=
+github.com/go-resty/resty/v2 v2.16.5/go.mod h1:hkJtXbA2iKHzJheXYvQ8snQES5ZLGKMwQ07xAwp/fiA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+golang.org/x/net v0.33.0 h1:74SYHlV8BIgHIFC/LrYkOGIwL19eTYXQ5wc6TBuO36I=
+golang.org/x/net v0.33.0/go.mod h1:HXLR5J+9DxmrqMwG9qjGCxZ+zKXxBru04zlTvWlWuN4=
+golang.org/x/time v0.6.0 h1:eTDhh4ZXt5Qf0augr54TN6suAUudPcawVZeIAPU7D4U=
+golang.org/x/time v0.6.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
Посмотрите на строчку srv := httptest.NewServer(handler): мы запускаем тестовый сервер с хендлером в качестве обработчика запросов. Это настоящий HTTP-сервер, запрос к которому можно отправить с помощью любого HTTP-клиента, что мы и делаем в обновлённом тесте.
Поскольку для тестов мы подключили стороннюю библиотеку resty — не забудем обновить зависимости нашего проекта с помощью команды $ go mod tidy.
Вывод результатов теста никак не изменится — это говорит о том, что тесты продолжают выполнять свою задачу, как и раньше.
Как итог в данной итерации мы привели тесты нашего кода к более правильному состоянию. В таком виде тесты будут проверять корректность работы нашего сервиса в наиболее приближенном к реальному взаимодествию с ним внешних пользователей.