### PR TITLE
Add environment variable support for server address in flag parsing

### DIFF
--- a/cmd/skill/flag.go
+++ b/cmd/skill/flag.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"flag"
+	"os"
 )
 
 // неэкспортированная переменная flagRunAddr содержит адрес и порт для запуска сервера
@@ -15,4 +16,12 @@ func parseFlags() {
 	flag.StringVar(&flagRunAddr, "a", ":8080", "address and port to run server")
 	// парсим переданные серверу аргументы в зарегистрированные переменные
 	flag.Parse()
+
+	// для случаев, когда в переменной окружения RUN_ADDR присутствует непустое значение,
+	// переопределим адрес запуска сервера,
+	// даже если он был передан через аргумент командной строки
+	if envRunAddr := os.Getenv("RUN_ADDR"); envRunAddr != "" {
+		flagRunAddr = envRunAddr
+	}
+
 }


### PR DESCRIPTION
Теперь мы можем конфигурировать навык Алисы любым удобным способом — через аргументы командной строки или с помощью переменных окружения.